### PR TITLE
FISH-13140: ANTLR invocation goal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+target/
+.factorypath
+.project
+.classpath
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018] Payara Foundation and/or affiliates -->
+<!-- Portions Copyright [2018,2026] Payara Foundation and/or affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -52,7 +52,7 @@
     </parent>
     <groupId>org.glassfish.build</groupId>
     <artifactId>glassfishbuild-maven-plugin</artifactId>
-    <version>3.2.20.payara-p2</version>
+    <version>3.2.20.payara-p3</version>
     <packaging>maven-plugin</packaging>
     <name>PayaraBuild Maven Plugin</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,26 @@
             <name>GlassFishBuild Maven Plugin Website</name>
             <url>java-net:/glassfish-svn/trunk/www/glassfishbuild-maven-plugin/</url>
         </site>
+        <repository>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-artifacts</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <snapshotRepository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </snapshotRepository>
     </distributionManagement>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018,2026] Payara Foundation and/or affiliates -->
+<!-- Portions Copyright 2018-2026 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 

--- a/src/main/java/org/glassfish/build/antlr/AntlrLauncher.java
+++ b/src/main/java/org/glassfish/build/antlr/AntlrLauncher.java
@@ -1,0 +1,141 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.build.antlr;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+
+class AntlrLauncher {
+
+    private final ClassLoader classLoader;
+    private final List<String> extraArgs;
+
+    static AntlrLauncher create(String extraArgs, List<Artifact> compileDeps, Log log) throws MojoExecutionException {
+        URL antlr = null;
+
+        for (Artifact artifact : compileDeps) {
+            if (artifact.getFile() != null && artifact.getFile().isFile()) {
+                try (JarFile jarFile = new JarFile(artifact.getFile())) {
+                    ZipEntry entry = jarFile.getEntry("antlr/Tool.class");
+                    if (entry != null) {
+                        log.info(String.format("Using antlr Tool.class from %s:%s:%s",
+                                artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion()));
+                        antlr = artifact.getFile().toURI().toURL();
+                        break;
+                    }
+                } catch (IOException e) {
+                    log.warn("Failed to probe artifact " + artifact.getId() + " for antlr.Tool", e);
+                }
+            }
+        }
+        if (antlr == null) {
+            throw new MojoExecutionException("antlr.Tool class not found in compile dependencies");
+        }
+        return new AntlrLauncher(extraArgs, new URLClassLoader(new URL[] {antlr}, ClassLoader.getSystemClassLoader()));
+    }
+
+    private AntlrLauncher(String extraArgs, ClassLoader classLoader) {
+        this.classLoader=classLoader;
+        if (extraArgs == null) {
+            this.extraArgs = Collections.emptyList();
+        } else {
+            this.extraArgs = Arrays.asList(extraArgs.split("\\s+"));
+        }
+    }
+
+    private String[] args(String outdir, String inputFile) {
+        List<String> args = new ArrayList<>(extraArgs);
+        args.add("-o");
+        args.add(outdir);
+        args.add(inputFile);
+        return args.toArray(new String[0]);
+    }
+
+    void execute(String outdir, String inputFile) throws MojoExecutionException {
+        PrintStream oldErr = System.err;
+        ByteArrayOutputStream errOS = new ByteArrayOutputStream();
+        PrintStream err = new PrintStream(errOS);
+        System.setErr(err);
+        ClassLoader context = Thread.currentThread().getContextClassLoader();
+        // Believe or not, this plugin also has transitive dependency on ANTLR 2, so we need to switch context class loading as well.
+        Thread.currentThread().setContextClassLoader(classLoader);
+
+        try {
+            classLoader.loadClass("antlr.Tool")
+                    .getMethod("main", new Class[] { String[].class })
+                    .invoke(null, new Object[] { args(outdir, inputFile) });
+        } catch (ClassNotFoundException e) {
+            throw new MojoExecutionException("could not locate class antlr.Tool", e);
+        } catch (NoSuchMethodException e) {
+            throw new MojoExecutionException("error locating antlt.Tool#main", e);
+        } catch (InvocationTargetException e) {
+            throw new MojoExecutionException("error executing antlt.Tool#main", e.getTargetException());
+        } catch (IllegalAccessException e) {
+            throw new MojoExecutionException("error executing antlt.Tool#main", e);
+        } catch (RuntimeException e) {
+            try {
+                throw new MojoExecutionException("Antlr execution failed: "
+                        + e.getMessage() + "\n Error output:\n"
+                        + errOS.toString("UTF-8"), e);
+            } catch (UnsupportedEncodingException ex) {
+                // UTF-8 cannot be unsupported
+                throw new AssertionError(ex);
+            }
+        } finally {
+            System.setErr(oldErr);
+            Thread.currentThread().setContextClassLoader(context);
+        }
+    }
+}

--- a/src/main/java/org/glassfish/build/antlr/AntlrMojo.java
+++ b/src/main/java/org/glassfish/build/antlr/AntlrMojo.java
@@ -1,0 +1,131 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.build.antlr;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+
+import static org.codehaus.plexus.util.StringUtils.isEmpty;
+
+/**
+ * Execute ANTLR 2 as required by some of Payara modules.
+ * Originally we would invoke Antlr plugin, which required classpath workarounds, and contained lots of options we didn't use.
+ * The plugin will output the sources under outputdir disregarding the packages, which is ok, though we rarely remember that.
+ *
+ *
+ * @author Patrik Dudits
+ * @version $Id$
+ *
+ * @goal antlr
+ * @phase generate-sources
+ * @requiresDependencyResolution compile
+ */
+public class AntlrMojo extends AbstractMojo {
+
+    /**
+     * Specifies the Antlr directory containing grammar files.
+     *
+     * @parameter default-value="${basedir}/src/main/antlr"
+     */
+    protected File sourceDirectory;
+
+    /**
+     * The Maven Project Object
+     *
+     * @parameter expression="${project}"
+     * @readonly
+     */
+    protected MavenProject project;
+
+    /**
+     * Specifies the destination directory where Antlr should generate files. <br/>
+     * See <a href="http://www.antlr2.org/doc/options.html#Command%20Line%20Options">Command Line Options</a>
+     *
+     * @parameter default-value="${project.build.directory}/generated-sources/antlr"
+     */
+    protected File outputDirectory;
+
+    /**
+     * Comma separated grammar file names or grammar pattern file names present in the <code>sourceDirectory</code>
+     * directory. <br/>
+     * See <a href="http://www.antlr2.org/doc/options.html#Command%20Line%20Options">Command Line Options</a>
+     *
+     * @parameter expression="${antlr.grammars}"
+     */
+    protected String grammars;
+
+    /**
+     * Extra arguments to antlr, such as <code>-trace</code> or <code>-diagnostic</code>, as per
+     * <a href="http://www.antlr2.org/doc/options.html#Command%20Line%20Options">Command Line Options</a>.
+     * Split into separate arguments by whitespace.
+     *
+     * @parameter expression="${antlr.args}"
+     */
+    protected String antlrArgs;
+
+    /**
+     * @throws MojoExecutionException
+     */
+    @Override
+    public void execute() throws MojoExecutionException {
+        if (isEmpty(grammars)) {
+            throw new MojoExecutionException("Grammars list is not defined via <grammars>");
+        }
+
+        // ANTLR liked to do System.exit(1) as error handling mechanism
+        System.setProperty("ANTLR_DO_NOT_EXIT", "true");
+
+        @SuppressWarnings("unchecked")
+        AntlrLauncher launcher = AntlrLauncher.create(antlrArgs, project.getCompileArtifacts(), getLog());
+
+        outputDirectory.mkdirs();
+        String outputDir = outputDirectory.getAbsolutePath();
+
+        for(String grammar : grammars.split(",\\s*")) {
+            getLog().info("performing grammar generation [" + grammar + "]");
+            launcher.execute(outputDir, new File(sourceDirectory, grammar).getAbsolutePath());
+        }
+        project.addCompileSourceRoot(outputDirectory.getAbsolutePath());
+    }
+
+}


### PR DESCRIPTION
This replaces use of antlr-maven-plugin with more straightfortward invocation of ANTLR that doesn't suffer classpath issues.

This new goal probes compile classpath for ANTLR presence and then launches ANTLR from there. This solves classpath issues that antlr plugin was having and also drops the need for dependency on `antlr:antlr` that maven plugin required.

Ultimately this unblocks use of `mvnd` as well as maven parallel builds for building Server that would otherwise fail in `persistence/cmp`.

I'll deploy the new version to payara-artifacts and follow up with server PR.